### PR TITLE
Don't perform an existence check in `get_target`

### DIFF
--- a/src/internals.rs
+++ b/src/internals.rs
@@ -129,10 +129,6 @@ pub fn exists(junction: &Path) -> io::Result<bool> {
 }
 
 pub fn get_target(junction: &Path) -> io::Result<PathBuf> {
-    // MSRV(1.63): use Path::try_exists instead
-    if !junction.exists() {
-        return Err(io::Error::new(io::ErrorKind::NotFound, "`junction` does not exist"));
-    }
     let file = helpers::open_reparse_point(junction, false)?;
     let mut data = BytesAsReparseDataBuffer::new();
     helpers::get_reparse_data_point(file.as_raw_handle(), data.as_mut_ptr())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,8 @@ pub fn exists<P: AsRef<Path>>(junction: P) -> io::Result<bool> {
 
 /// Gets the target of the specified junction point.
 ///
+/// This returns the target path of the junction point, even if the target does not exist.
+///
 /// N.B. Only works on NTFS.
 ///
 /// # Example

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -252,6 +252,20 @@ fn get_target_user_dirs() {
 }
 
 #[test]
+fn get_target_target_no_exist() {
+    let tmpdir = create_tempdir();
+
+    let target = tmpdir.path().join("target");
+    let junction = tmpdir.path().join("junction");
+
+    super::create(&target, &junction).unwrap();
+    match super::get_target(&junction) {
+        Ok(t) => assert_eq!(t, target),
+        other => panic!("get_target should succeed when target does not exist: {:?}", other),
+    }
+}
+
+#[test]
 fn create_with_verbatim_prefix_paths() {
     // Regression test for https://github.com/tesuji/junction/issues/30
     let tmpdir = create_tempdir();


### PR DESCRIPTION
~~WIP, leaving in draft until I confirm the CI passes 🙂~~

This removes the destination existence check from `get_target`. In other words, `get_target` still validates that the junction itself exists, but not that the junction's destination directory exists. This is consistent with what other languages' junction APIs do, per discussion in #34. It is however a breaking change, so a major version is in order.

Closes #34.